### PR TITLE
Fix: Pass CLAUDE_CODE_OAUTH_TOKEN to shell Claude CLI commands

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -615,15 +615,15 @@ function handleShellConnection(ws) {
                         if (os.platform() === 'win32') {
                             if (hasSession && sessionId) {
                                 // Try to resume session, but with fallback to new session if it fails
-                                shellCommand = `Set-Location -Path "${projectPath}"; claude --resume ${sessionId}; if ($LASTEXITCODE -ne 0) { claude }`;
+                                shellCommand = `Set-Location -Path "${projectPath}"; $env:CLAUDE_CODE_OAUTH_TOKEN="${process.env.CLAUDE_CODE_OAUTH_TOKEN || ''}"; claude --resume ${sessionId}; if ($LASTEXITCODE -ne 0) { $env:CLAUDE_CODE_OAUTH_TOKEN="${process.env.CLAUDE_CODE_OAUTH_TOKEN || ''}"; claude }`;
                             } else {
-                                shellCommand = `Set-Location -Path "${projectPath}"; ${command}`;
+                                shellCommand = `Set-Location -Path "${projectPath}"; $env:CLAUDE_CODE_OAUTH_TOKEN="${process.env.CLAUDE_CODE_OAUTH_TOKEN || ''}"; ${command}`;
                             }
                         } else {
                             if (hasSession && sessionId) {
-                                shellCommand = `cd "${projectPath}" && claude --resume ${sessionId} || claude`;
+                                shellCommand = `cd "${projectPath}" && env CLAUDE_CODE_OAUTH_TOKEN="${process.env.CLAUDE_CODE_OAUTH_TOKEN || ''}" claude --resume ${sessionId} || env CLAUDE_CODE_OAUTH_TOKEN="${process.env.CLAUDE_CODE_OAUTH_TOKEN || ''}" claude`;
                             } else {
-                                shellCommand = `cd "${projectPath}" && ${command}`;
+                                shellCommand = `cd "${projectPath}" && env CLAUDE_CODE_OAUTH_TOKEN="${process.env.CLAUDE_CODE_OAUTH_TOKEN || ''}" ${command}`;
                             }
                         }
                     }


### PR DESCRIPTION
## Summary
- Fixes OAuth token not being passed through to Claude CLI when using the shell feature
- Adds CLAUDE_CODE_OAUTH_TOKEN environment variable to both Windows and Unix command execution
- Includes fallback handling for session resume failures

## Problem
When using the Claude Code web UI shell feature, the OAuth token was not being passed to the Claude CLI subprocess, causing authentication failures.

## Solution
Modified `server/index.js` to:
- Set `$env:CLAUDE_CODE_OAUTH_TOKEN` for Windows PowerShell commands  
- Use `env CLAUDE_CODE_OAUTH_TOKEN` prefix for Unix/Linux commands
- Apply to both session resume and new session scenarios
- Maintain existing fallback logic for failed session resumes

## Test Plan
- [ ] Test shell feature on Windows with OAuth authentication
- [ ] Test shell feature on Unix/Linux with OAuth authentication  
- [ ] Verify session resume works with token passthrough
- [ ] Verify fallback to new session works when resume fails